### PR TITLE
Conformance to `Hashable`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,10 @@ import PackageDescription
 
 let package = Package(
     name: "SemVer",
+    platforms: [
+        .macOS(.v10_10),
+        .iOS(.v11),
+    ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
     platforms: [
         .macOS(.v10_10),
         .iOS(.v11),
+        .tvOS(.v11),
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Sources/SemVer/Conveniences.swift
+++ b/Sources/SemVer/Conveniences.swift
@@ -157,7 +157,7 @@ extension Int: ObjcComparable {
 
 public extension NSRange {
     /// If this represents a null or unfound range, this returns `nil`; else, this returns the range itself
-    public var orNil: NSRange? {
+    var orNil: NSRange? {
         if location == NSNotFound {
             return nil
         }

--- a/Sources/SemVer/Semantic Version + Hashable.swift
+++ b/Sources/SemVer/Semantic Version + Hashable.swift
@@ -1,0 +1,32 @@
+//
+//  Semantic Version + Hashable.swift
+//  SemVer
+//
+//  Created by Ben Leggiero on 2020-04-19.
+//  Copyright © 2020 Ben Leggiero BH-1-PS.
+//
+
+import Foundation
+
+
+
+extension SemanticVersion: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(major)
+        hasher.combine(minor)
+        hasher.combine(patch ?? 0)
+        if let preRelease = preRelease {
+            hasher.combine(preRelease)
+        }
+    }
+}
+
+
+
+extension SemanticVersion.PreRelease: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        self.identifiers.forEach {
+            hasher.combine($0)
+        }
+    }
+}

--- a/Sources/SemVer/Semantic Version.swift
+++ b/Sources/SemVer/Semantic Version.swift
@@ -153,7 +153,7 @@ public extension SemanticVersion {
     /// If this returns `true`, the build may change drastically at any time and must not be considered stable.
     ///
     /// https://semver.org/spec/v2.0.0.html#spec-item-4
-    public var isInitialDevelopment: Bool {
+    var isInitialDevelopment: Bool {
         return major == 0
     }
     
@@ -162,7 +162,7 @@ public extension SemanticVersion {
     /// number will accurately reflect changes to the build.
     ///
     /// https://semver.org/spec/v2.0.0.html#spec-item-5
-    public var isPublic: Bool {
+    var isPublic: Bool {
         return major > 0
     }
 }
@@ -328,13 +328,13 @@ public struct SemanticVersionBuild: SemanticVersion.Extension {
 
 public extension SemanticVersion.Extension {
     
-    public typealias PreRelease = SemanticVersionPreRelease
-    public typealias Build = SemanticVersionBuild
+    typealias PreRelease = SemanticVersionPreRelease
+    typealias Build = SemanticVersionBuild
     
     
     
     /// Creates a string of period-separated identifiers, so `["public", "RC", "1"]` would become `"public.RC.1"`
-    public var description: String {
+    var description: String {
         return identifiers.joined(separator: ".")
     }
     
@@ -342,7 +342,7 @@ public extension SemanticVersion.Extension {
     /// Creates a string suitable for naïve concatenation with a semantic version string.
     /// For example, a pre-release extension like `["RC", "1"]` would become `"-RC.1"`, and a build like
     /// `["2018", "01", "15"]` would become `"+2018.01.15"`.
-    public var descriptionWithPrefix: String {
+    var descriptionWithPrefix: String {
         return "\(type(of: self).prefix)\(description)"
     }
     
@@ -350,7 +350,7 @@ public extension SemanticVersion.Extension {
     /// Creates a new extension by converting the given array into an array of strings
     ///
     /// - Parameter identifiers: Soon-to-be identifiers
-    public init(identifiers: [CustomStringConvertible]) {
+    init(identifiers: [CustomStringConvertible]) {
         self.init(identifiers: identifiers.map { $0.description })
     }
     
@@ -360,7 +360,7 @@ public extension SemanticVersion.Extension {
     ///
     /// - Parameter rawString: A raw representation of a semantic version string.
     ///                        This should match the regex `/^[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*$/`.
-    public init(_ rawString: Substring) {
+    init(_ rawString: Substring) {
         self.init(identifiers: rawString.split(separator: ".").map { String($0) })
     }
     #endif
@@ -370,7 +370,7 @@ public extension SemanticVersion.Extension {
     ///
     /// - Parameter rawString: A raw representation of a semantic version string.
     ///                        This should match the regex `/^[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*$/`.
-    public init(_ rawString: String) {
+    init(_ rawString: String) {
         self.init(identifiers: rawString.split(separator: ".").map { String($0) })
     }
     
@@ -378,7 +378,7 @@ public extension SemanticVersion.Extension {
     /// Creates a new extension by converting the given varargs into an array of strings
     ///
     /// - Parameter identifiers: Soon-to-be identifiers
-    public init(_ identifiers: CustomStringConvertible...) {
+    init(_ identifiers: CustomStringConvertible...) {
         self.init(identifiers: identifiers)
     }
     
@@ -386,7 +386,7 @@ public extension SemanticVersion.Extension {
     /// Creates a new extension by converting the given array/varargs into an array of strings
     ///
     /// - Parameter identifiers: Soon-to-be identifiers
-    public init(arrayLiteral elements: CustomStringConvertible...) {
+    init(arrayLiteral elements: CustomStringConvertible...) {
         self.init(identifiers: elements)
     }
     
@@ -394,7 +394,7 @@ public extension SemanticVersion.Extension {
     /// Creaetes a new extension by converting the given integer into a string and assuming that is the only identifier
     ///
     /// - Parameter value: The only identifier, to become a string
-    public init(integerLiteral value: UInt) {
+    init(integerLiteral value: UInt) {
         self.init(identifiers: [value])
     }
     
@@ -403,7 +403,7 @@ public extension SemanticVersion.Extension {
     ///
     /// - Parameter rawString: A raw representation of a semantic version string.
     ///                        This should match the regex `/^[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*$/`.
-    public init(stringLiteral value: String) {
+    init(stringLiteral value: String) {
         self.init(value)
     }
 }
@@ -421,7 +421,7 @@ public extension SemanticVersion.Extension {
     /// - Returns: `true` iff `lhs` is less than, or has lower precedence than, `rhs`. If they have the same
     ///            precedence, this will still return `false`.
     /// - Note:  To determine the exact order, use `compare(lhs:rhs:)`
-    public static func <(lhs: Self, rhs: Self) -> Bool {
+    static func <(lhs: Self, rhs: Self) -> Bool {
         return compare(lhs: lhs, rhs: rhs) == .orderedAscending
     }
     
@@ -433,7 +433,7 @@ public extension SemanticVersion.Extension {
     ///   - lhs: The first extension to compare
     ///   - rhs: The second extension to compare
     /// - Returns: The order of the extensions
-    public static func compare(lhs: Self, rhs: Self) -> ComparisonResult {
+    static func compare(lhs: Self, rhs: Self) -> ComparisonResult {
         
         if lhs == rhs {
             return .orderedSame
@@ -489,7 +489,7 @@ public extension SemanticVersion.Extension {
     ///   - lhs: One extension
     ///   - rhs: Another extension
     /// - Returns: `true` iff the given two extensions are equal
-    public static func ==(lhs: Self, rhs: Self) -> Bool {
+    static func ==(lhs: Self, rhs: Self) -> Bool {
         let (lhsIds, rhsIds) = (lhs.identifiers, rhs.identifiers)
         return lhsIds.count == rhsIds.count && !lhsIds.zip(with: rhsIds).contains(where: { $0.0 != $0.1 })
     }

--- a/Tests/SemVerTests/SemVer+Hashable Tests.swift
+++ b/Tests/SemVerTests/SemVer+Hashable Tests.swift
@@ -1,0 +1,151 @@
+//
+//  SemVer+Hashable Tests.swift
+//  SemVer
+//
+//  Created by Ben Leggiero on 2020-04-19.
+//  Copyright © 2020 Ben Leggiero BH-1-PS.
+//
+
+import XCTest
+@testable import SemVer
+
+
+
+class SemVerHashableTests: XCTestCase {
+    func testHashable() {
+        let v0_0_0 =       SemVer(0,0,0)
+        let v0_0_0__0 =    SemVer(0,0,0, preRelease: 0)
+        let v0_0_0__0__0 = SemVer(0,0,0, preRelease: 0, build: 0)
+        let v0_0_0__0__1 = SemVer(0,0,0, preRelease: 0, build: 1)
+        let v0_0_0__1__0 = SemVer(0,0,0, preRelease: 1, build: 0)
+        let v0_0_0__1__1 = SemVer(0,0,0, preRelease: 1, build: 1)
+        
+        let v0_0_1 =       SemVer(0,0,1)
+        let v0_0_1__0 =    SemVer(0,0,1, preRelease: 0)
+        let v0_0_1__0__0 = SemVer(0,0,1, preRelease: 0, build: 0)
+        let v0_0_1__0__1 = SemVer(0,0,1, preRelease: 0, build: 1)
+        let v0_0_1__1__0 = SemVer(0,0,1, preRelease: 1, build: 0)
+        let v0_0_1__1__1 = SemVer(0,0,1, preRelease: 1, build: 1)
+        
+        let v0_1_0 =       SemVer(0,1,0)
+        let v0_1_0__0 =    SemVer(0,1,0, preRelease: 0)
+        let v0_1_0__0__0 = SemVer(0,1,0, preRelease: 0, build: 0)
+        let v0_1_0__0__1 = SemVer(0,1,0, preRelease: 0, build: 1)
+        let v0_1_0__1__0 = SemVer(0,1,0, preRelease: 1, build: 0)
+        let v0_1_0__1__1 = SemVer(0,1,0, preRelease: 1, build: 1)
+        
+        let v0_1_1 =       SemVer(0,1,1)
+        let v0_1_1__0 =    SemVer(0,1,1, preRelease: 0)
+        let v0_1_1__0__0 = SemVer(0,1,1, preRelease: 0, build: 0)
+        let v0_1_1__0__1 = SemVer(0,1,1, preRelease: 0, build: 1)
+        let v0_1_1__1__0 = SemVer(0,1,1, preRelease: 1, build: 0)
+        let v0_1_1__1__1 = SemVer(0,1,1, preRelease: 1, build: 1)
+        
+        let v1_0_0 =       SemVer(1,0,0)
+        let v1_0_0__0 =    SemVer(1,0,0, preRelease: 0)
+        let v1_0_0__0__0 = SemVer(1,0,0, preRelease: 0, build: 0)
+        let v1_0_0__0__1 = SemVer(1,0,0, preRelease: 0, build: 1)
+        let v1_0_0__1__0 = SemVer(1,0,0, preRelease: 1, build: 0)
+        let v1_0_0__1__1 = SemVer(1,0,0, preRelease: 1, build: 1)
+        
+        let v1_0_1 =       SemVer(1,0,1)
+        let v1_0_1__0 =    SemVer(1,0,1, preRelease: 0)
+        let v1_0_1__0__0 = SemVer(1,0,1, preRelease: 0, build: 0)
+        let v1_0_1__0__1 = SemVer(1,0,1, preRelease: 0, build: 1)
+        let v1_0_1__1__0 = SemVer(1,0,1, preRelease: 1, build: 0)
+        let v1_0_1__1__1 = SemVer(1,0,1, preRelease: 1, build: 1)
+        
+        let v2_0_0 =       SemVer(2,0,0)
+        let v2_0_0__0 =    SemVer(2,0,0, preRelease: 0)
+        let v2_0_0__0__0 = SemVer(2,0,0, preRelease: 0, build: 0)
+        let v2_0_0__0__1 = SemVer(2,0,0, preRelease: 0, build: 1)
+        let v2_0_0__1__0 = SemVer(2,0,0, preRelease: 1, build: 0)
+        let v2_0_0__1__1 = SemVer(2,0,0, preRelease: 1, build: 1)
+        
+        let v2_0_1 =       SemVer(2,0,1)
+        let v2_0_1__0 =    SemVer(2,0,1, preRelease: 0)
+        let v2_0_1__0__0 = SemVer(2,0,1, preRelease: 0, build: 0)
+        let v2_0_1__0__1 = SemVer(2,0,1, preRelease: 0, build: 1)
+        let v2_0_1__1__0 = SemVer(2,0,1, preRelease: 1, build: 0)
+        let v2_0_1__1__1 = SemVer(2,0,1, preRelease: 1, build: 1)
+        
+        
+        let all: Set<SemVer> = [
+            v0_0_0,       // +1 = 1
+            v0_0_0__0,    // +1 = 2
+            v0_0_0__0__0, // +0 = 2
+            v0_0_0__0__1, // +0 = 2
+            v0_0_0__1__0, // +1 = 3
+            v0_0_0__1__1, // +0 = 3
+            
+            v0_0_1,       // +1 = 4
+            v0_0_1__0,    // +1 = 5
+            v0_0_1__0__0, // +0 = 5
+            v0_0_1__0__1, // +0 = 5
+            v0_0_1__1__0, // +1 = 6
+            v0_0_1__1__1, // +0 = 6
+            
+            v0_1_0,       // +1 = 7
+            v0_1_0__0,    // +1 = 7
+            v0_1_0__0__0, // +0 = 8
+            v0_1_0__0__1, // +0 = 8
+            v0_1_0__1__0, // +1 = 9
+            v0_1_0__1__1, // +0 = 9
+            
+            v0_1_1,       // +1 = 10
+            v0_1_1__0,    // +1 = 11
+            v0_1_1__0__0, // +0 = 11
+            v0_1_1__0__1, // +0 = 11
+            v0_1_1__1__0, // +1 = 12
+            v0_1_1__1__1, // +0 = 12
+            
+            v1_0_0,       // +1 = 13
+            v1_0_0__0,    // +1 = 14
+            v1_0_0__0__0, // +0 = 14
+            v1_0_0__0__1, // +0 = 14
+            v1_0_0__1__0, // +1 = 15
+            v1_0_0__1__1, // +0 = 15
+            
+            v1_0_1,       // +1 = 16
+            v1_0_1__0,    // +1 = 17
+            v1_0_1__0__0, // +0 = 17
+            v1_0_1__0__1, // +0 = 17
+            v1_0_1__1__0, // +1 = 18
+            v1_0_1__1__1, // +0 = 18
+            
+            v2_0_0,       // +1 = 19
+            v2_0_0__0,    // +1 = 20
+            v2_0_0__0__0, // +0 = 20
+            v2_0_0__0__1, // +0 = 20
+            v2_0_0__1__0, // +1 = 21
+            v2_0_0__1__1, // +0 = 21
+            
+            v2_0_1,       // +1 = 22
+            v2_0_1__0,    // +1 = 23
+            v2_0_1__0__0, // +0 = 23
+            v2_0_1__0__1, // +0 = 23
+            v2_0_1__1__0, // +1 = 24
+            v2_0_1__1__1, // +0 = 24
+        ]
+        XCTAssertEqual(all.count, 24)
+        
+        XCTAssertTrue(all.allPairsSatisfy { $0.hashValue != $1.hashValue })
+    }
+}
+
+
+
+private extension Collection {
+    func allPairsSatisfy(predicate: (Element, Element) -> Bool) -> Bool {
+        for indexA in indices {
+            for indexB in indices
+                where indexA != indexB
+            {
+                if !predicate(self[indexA], self[indexB]) {
+                    return false
+                }
+            }
+        }
+        return true
+    }
+}


### PR DESCRIPTION
To achieve this, I also had to restrict the supported platforms to macOS 10.10+ and iOS 11+. This will likely mean another major version increment.

Also applied Swift 5 visibility implication.
