### PR TITLE
#17: Removed Swift ≤4 support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -45,3 +45,17 @@ nil == SemVer("1.2.3.4")
 
 # License #
 This is licensed under [BH-1-PS](https://github.com/BlueHuskyStudios/Licenses/blob/master/Licenses/BH-1-PS.txt).
+
+
+
+# Requirements #
+
+This package requires:
+- Swift 5.1 or newer
+- One of:
+    - macOS 10.14.4 or newer
+    - iOS 11 or newer
+    - tvOS 11 or newer
+    - Ubuntu 16.04 or newer
+
+Other version combinations may work, but have not been tested.

--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ This package requires:
 - Swift 5.1 or newer
 - One of:
     - macOS 10.14.4 or newer
-    - iOS 11 or newer
-    - tvOS 11 or newer
     - Ubuntu 16.04 or newer
 
-Other version combinations may work, but have not been tested.
+Other version & platform combinations may work, but have not been tested.

--- a/Sources/SemVer/Semantic Version.swift
+++ b/Sources/SemVer/Semantic Version.swift
@@ -399,7 +399,6 @@ public extension SemanticVersion.Extension {
     }
     
     
-    #if swift(>=4)
     /// Creates a new extension by separating the given raw string by any periods in it
     ///
     /// - Parameter rawString: A raw representation of a semantic version string.
@@ -407,7 +406,6 @@ public extension SemanticVersion.Extension {
     init(_ rawString: Substring) {
         self.init(identifiers: rawString.split(separator: ".").map { String($0) })
     }
-    #endif
     
     
     /// Creates a new extension by separating the given raw string by any periods in it
@@ -546,12 +544,6 @@ public extension SemanticVersion.Extension {
 // #3: https://github.com/RougeWare/Swift-SemVer/issues/3
 private extension NSTextCheckingResult {
     
-    #if swift(>=4)
-    typealias StringOrSubstring = Substring
-    #else
-    typealias StringOrSubstring = String
-    #endif
-    
     /// Finds the group located at the given index in this text checking result, within the given string
     ///
     /// - Parameters:
@@ -559,7 +551,7 @@ private extension NSTextCheckingResult {
     ///   - string:     The string to search
     ///
     /// - Returns: The substring at the given group index, or `nil` if there is none
-    func group(_ groupIndex: Int, in string: String) -> StringOrSubstring? {
+    func group(_ groupIndex: Int, in string: String) -> Substring? {
         guard let range = self.range(at: groupIndex).orNil else {
             return nil
         }
@@ -574,7 +566,7 @@ private extension NSTextCheckingResult {
     ///
     /// - Returns: The substring at the given group index, or `nil` if there is none
     @available(macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
-    func group(_ groupName: String, in string: String) -> StringOrSubstring? {
+    func group(_ groupName: String, in string: String) -> Substring? {
         guard let range = self.range(withName: groupName).orNil else {
             return nil
         }
@@ -590,7 +582,7 @@ private extension NSTextCheckingResult {
     ///   - string: The string to search
     ///
     /// - Returns: The substring at the given range, or `nil` if there is none
-    private func _group(range: NSRange, in string: String) -> StringOrSubstring? {
+    private func _group(range: NSRange, in string: String) -> Substring? {
         guard range.location != NSNotFound else {
             return nil
         }

--- a/Tests/SemVerTests/SemVerTests.swift
+++ b/Tests/SemVerTests/SemVerTests.swift
@@ -93,6 +93,7 @@ class SemVerTests: XCTestCase {
         XCTAssertNil(SemVer("1.2.-3"))
         XCTAssertNil(SemVer("1.2.3.4"))
         
+        // https://github.com/RougeWare/Swift-SemVer/issues/14
         XCTAssertNil(SemVer(1,0,0, preRelease: "01"))
         XCTAssertNil(SemVer("1.0.0-01"))
         XCTAssertNil(SemVer("1.0.0-01.02.03"))


### PR DESCRIPTION
Also noted why one test is there. If it's failing, it's because that issue has not been resolved.

This resolves #17 